### PR TITLE
Updating the way that the BEN writer works.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,12 +123,14 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "binary-ensemble"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b79a285f14f79d96a86d019e178c01ea4fbaed41087deaf8be83215387f833"
+checksum = "33b15d09d94e161a9c57b4f47fa652bed1a84a9187f09fdaf324294841e1896c"
 dependencies = [
  "byteorder",
  "clap 4.5.4",
+ "pcompress",
+ "pipe",
  "serde_json",
  "xz2",
 ]
@@ -1014,6 +1016,15 @@ checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "pipe"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7b8f27da217eb966df4c58d4159ea939431950ca03cf782c22bd7c5c1d8d75"
+dependencies = [
+ "crossbeam-channel",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "frcw"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "approx 0.5.1",
  "binary-ensemble",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0.64"
 sha3 = "0.10.0"
 snafu = "0.7.0"
 itertools = "0.10.2"
-binary-ensemble = "^0.1.1"
+binary-ensemble = "^0.2.0"
 
 [dev-dependencies]
 rstest = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frcw"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Parker J. Rule <parker.rule@tufts.edu>", "Peter Rock <peter.r.rock2@gmail.com>"]
 edition = "2021"
 

--- a/benches/recom.rs
+++ b/benches/recom.rs
@@ -17,7 +17,9 @@ const RNG_SEED: u64 = 153434375;
 struct DummyWriter {}
 
 impl StatsWriter for DummyWriter {
-    fn init(&mut self, _graph: &Graph, _partition: &Partition) -> Result<(), std::io::Error> { Ok(())}
+    fn init(&mut self, _graph: &Graph, _partition: &Partition) -> Result<(), std::io::Error> {
+        Ok(())
+    }
 
     fn step(
         &mut self,
@@ -30,7 +32,13 @@ impl StatsWriter for DummyWriter {
         Ok(())
     }
 
-    fn close(&mut self) -> Result<(), std::io::Error> { Ok(())}
+    fn close(&mut self) -> Result<(), std::io::Error> {
+        Ok(())
+    }
+}
+
+fn main() {
+    unimplemented!("This file has not been set up to run yet.");
 }
 
 // fn grid_single_thread_recom_benchmark(c: &mut Criterion) {

--- a/src/stats/writers.rs
+++ b/src/stats/writers.rs
@@ -524,6 +524,15 @@ impl StatsWriter for PcompressWriter {
         proposal: &RecomProposal,
         counts: &SelfLoopCounts,
     ) -> Result<()> {
+        // Write out self-loops first. The counts here
+        // are the number of self-loops since the last
+        // accepted proposal (i.e. the number of times the
+        // last proposal was repeated before acceptance).
+        self.diff.reset();
+        for _ in 0..counts.sum() {
+            export_diff(&mut self.writer, &self.diff);
+        }
+
         // Write out the actual delta.
         self.diff.reset();
         for &node in proposal.a_nodes.iter() {
@@ -534,11 +543,6 @@ impl StatsWriter for PcompressWriter {
         }
         export_diff(&mut self.writer, &self.diff);
 
-        // Write out self-loops.
-        self.diff.reset();
-        for _ in 0..counts.sum() {
-            export_diff(&mut self.writer, &self.diff);
-        }
         Ok(())
     }
 


### PR DESCRIPTION
This PR mainly fixes some of the stuff having to do with the `PCompress` and `BEN` writers. We fix a small error in the PCompress writer coming from a misordering of when to push the diffs, and update the BEN writer to use the new MkvChain variant. We also update the region-aware so that it is completely consistent with the latest GerryChain release